### PR TITLE
Use only png files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=$HOME/miniconda/bin:$PATH
+  - export PATH=$HOME/miniconda2/bin:$PATH
   - conda update -y conda
 install: conda install -y --file requirements.txt
 script: nosetests

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/kjshim/autofpop.svg?branch=master)](https://travis-ci.org/kjshim/autofpop)
+
 Auto solver for friends pop
 
 # Prerequisites

--- a/autofpop/recognition.py
+++ b/autofpop/recognition.py
@@ -6,6 +6,7 @@ from skimage import transform
 from skimage import color
 from skimage.feature import match_template
 import os
+import glob
 from skimage import exposure
 from skimage import feature
 from skimage import color
@@ -52,9 +53,9 @@ class ImgRecognizer:
         self.downscale_res = (50, 50)
 
     def _load(self, path, target_value):
-        training_imgs = os.listdir(path)
+        training_imgs = glob.glob(os.path.join(path, '*.png'))
         for f in training_imgs:
-            img = io.imread(path+'/'+f)
+            img = io.imread(f)
             self.training_data.append(self.img2feat(img))
             self.target_values.append(target_value)
 

--- a/autofpop/recognition.py
+++ b/autofpop/recognition.py
@@ -118,12 +118,18 @@ class ImgRecognizer:
         return result
 
     def predict(self, img):
+        result = self.predict_(img)
+        self.save_image_log(img, result)
+        return result
+
+    def predict_(self, img):
         feat = self.img2feat(img)
         afterpca = self.pca.transform(feat)
         result = int(self.clf.predict(afterpca))
+        return result
+
+    def save_image_log(self, img, result):
         outdir = os.path.join("data/PredictionLog")
         if not os.path.exists(outdir):
             os.makedirs(outdir)
         io.imsave(os.path.join(outdir,  CELL_NAMES[result] + "_" + str(uuid.uuid4()) + ".png"), transform.resize(img, self.downscale_res))
-        return result
-

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -1,0 +1,23 @@
+from autofpop import recognition
+from autofpop.friendspop import CELL_NAMES
+from skimage import io
+import os
+import glob
+
+def test_ImgRecognizer_example():
+	def value_of(name):
+	    return next(
+	        (key for key, value in CELL_NAMES.items() if value == 'BLACK'),
+	        None)
+	model = recognition.ImgRecognizer()
+	model.load()
+	model.train()
+
+	root = 'Training_Data'
+	klass = 'BLACK'
+	path = glob.glob(os.path.join(root, klass, '*.png'))[0]
+	img = io.imread(path)
+
+	result = model.predict_(img)
+	expected = value_of(klass)
+	assert result == expected


### PR DESCRIPTION
autofpop.recognition.ImgRecognition.load assumes all files as png, so it fails with non image files such as .DS_Store.
This pull request makes ImgRecognition.load finds only *.png files.
